### PR TITLE
fix: remove fastmcp <3 upper bound to resolve fakeredis incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = "MCP server for searching and analyzing academic papers via Semant
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "fastmcp>=2.0,<3",
-    "httpx>=0.27",
-    "pydantic>=2.0",
+    "fastmcp>=3.2,<4",
+    "httpx>=0.28",
+    "pydantic>=2.12",
 ]
 
 [project.scripts]
@@ -22,11 +22,11 @@ packages = ["src/semantic_scholar_mcp"]
 
 [dependency-groups]
 dev = [
-    "pytest>=8.0",
-    "pytest-asyncio>=0.24",
-    "pytest-cov>=4.0",
-    "ruff>=0.9",
-    "ty>=0.0.1a6",
+    "pytest>=9.0",
+    "pytest-asyncio>=1.3",
+    "pytest-cov>=7.1",
+    "ruff>=0.15",
+    "ty>=0.0.29",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_server_init.py
+++ b/tests/test_server_init.py
@@ -4,12 +4,19 @@ This module tests the MCP server initialization, tool registration,
 client singleton behavior, and cleanup handler registration.
 """
 
+import asyncio
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from semantic_scholar_mcp import server
+
+
+def _get_registered_tool_names() -> set[str]:
+    """Get registered tool names via the public async API."""
+    tools = asyncio.run(server.mcp.list_tools())
+    return {t.name for t in tools}
 
 
 @pytest.fixture(autouse=True)
@@ -42,25 +49,19 @@ class TestToolRegistration:
 
     def test_expected_number_of_tools_registered(self) -> None:
         """Test that all 14 expected tools are registered."""
-        # The server registers exactly 14 tools
-        # Access internal _tools dict directly (synchronous access)
-        tools = server.mcp._tool_manager._tools
-        assert len(tools) == 14
+        assert len(_get_registered_tool_names()) == 14
 
     def test_search_papers_tool_registered(self) -> None:
         """Test that search_papers tool is registered."""
-        tools = server.mcp._tool_manager._tools
-        assert "search_papers" in tools
+        assert "search_papers" in _get_registered_tool_names()
 
     def test_get_paper_details_tool_registered(self) -> None:
         """Test that get_paper_details tool is registered."""
-        tools = server.mcp._tool_manager._tools
-        assert "get_paper_details" in tools
+        assert "get_paper_details" in _get_registered_tool_names()
 
     def test_export_bibtex_tool_registered(self) -> None:
         """Test that export_bibtex tool is registered."""
-        tools = server.mcp._tool_manager._tools
-        assert "export_bibtex" in tools
+        assert "export_bibtex" in _get_registered_tool_names()
 
     def test_all_expected_tools_registered(self) -> None:
         """Test that all expected tool names are registered."""
@@ -80,9 +81,7 @@ class TestToolRegistration:
             "clear_tracked_papers",
             "export_bibtex",
         }
-        tools = server.mcp._tool_manager._tools
-        tool_names = set(tools.keys())
-        assert tool_names == expected_tools
+        assert _get_registered_tool_names() == expected_tools
 
 
 class TestClientSingleton:


### PR DESCRIPTION
Fixes #5

## Summary

- `fastmcp 2.x` → `docket` → `fakeredis` dependency chain causes `ImportError` on startup because `fakeredis >=2.27` renamed `FakeConnection` to `FakeRedisConnection`
- Upgrade `fastmcp` from `>=2.0,<3` to `>=3.2,<4`, which dropped the `docket` dependency entirely, eliminating the broken transitive chain
- Bump all dependency lower bounds to current versions (`httpx >=0.28`, `pydantic >=2.12`, dev deps updated accordingly)
- Update `test_server_init.py` to use the public `list_tools()` API instead of the removed `_tool_manager` private attribute
- No changes to application code — `FastMCP`, `mcp.tool()`, and `mcp.run()` are backward-compatible in fastmcp 3.x

## Test plan

- [x] Server starts successfully with fastmcp 3.2.3, all 14 tools registered
- [x] Full test suite passes: 421/421, 97% coverage